### PR TITLE
Removed unnecessary commas

### DIFF
--- a/regdiffusion/trainer.py
+++ b/regdiffusion/trainer.py
@@ -141,8 +141,8 @@ class RegDiffusionTrainer:
         # Prepare Data ---------------------------------------------------------
         if (exp_array.sum(0) == 0).sum() > 0:
             warnings.warn(
-                "Some columns in the exp_array contains all zero values, ",
-                "which often causes trouble in inference. Please consider ",
+                "Some columns in the exp_array contains all zero values, "
+                "which often causes trouble in inference. Please consider "
                 "removing these columns before continuing. "
             )
         if cell_types is None:


### PR DESCRIPTION
```~/.local/lib/python3.10/site-packages/regdiffusion/trainer.py in __init__(self, exp_array, cell_types, T, start_noise, end_noise, time_dim, celltype_dim, hidden_dims, init_coef, lr_nn, lr_adj, weight_decay_nn, weight_decay_adj, sparse_loss_coef, adj_dropout, batch_size, n_steps, train_split, train_split_seed, device, compile, evaluator, eval_on_n_steps, logger)
    141         # Prepare Data ---------------------------------------------------------
    142         if (exp_array.sum(0) == 0).sum() > 0:
--> 143             warnings.warn(
    144                 "Some columns in the exp_array contains all zero values, ",
    145                 "which often causes trouble in inference. Please consider ",

TypeError: 'str' object cannot be interpreted as an integer
```